### PR TITLE
fix(manager): revert df.map() to df.applymap() for pandas <2.1

### DIFF
--- a/views_stepshifter/manager/stepshifter_manager.py
+++ b/views_stepshifter/manager/stepshifter_manager.py
@@ -45,7 +45,7 @@ class StepshifterManager(ForecastingModelManager):
             else:
                 return 0 if (value == np.inf or value == -np.inf or value < 0 or np.isnan(value)) else value
 
-        df = df.map(standardize_value)
+        df = df.applymap(standardize_value)
 
         return df
 


### PR DESCRIPTION
## Summary

- Reverts `df.map(standardize_value)` → `df.applymap(standardize_value)` in `_get_standardized_df()`

## Root cause

Commit `06e73a9` changed `applymap()` to `map()` as a "deprecated API fix". However, `DataFrame.map()` was only added in pandas 2.1.0. The production environment runs pandas 1.5.3, causing `AttributeError: 'DataFrame' object has no attribute 'map'` during model evaluation for all stepshifter models.

## Test plan

- [ ] Re-run `bittersweet_symphony` integration test (calibration + validation)
- [ ] Verify evaluation phase completes without `AttributeError`