### PR TITLE
A1 — ADR-003 E2 load-time stamp guard (D-18, closes #86)

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,9 +1,9 @@
 # Technical Risk Register — views-stepshifter
 
-**Last updated:** 2026-06-14
+**Last updated:** 2026-06-21
 **Governing ADR:** Pending (will be added when base docs are adopted)
 **Total entries:** 35
-**Concerns:** Open 32 | Resolved 1 | Invalidated 2
+**Concerns:** Open 31 | Resolved 2 | Invalidated 2
 
 > **ID convention:** This register uses the `D-xx` (Debt) prefix for all concern entries; there are no disagreement entries. IDs are permanent and sequential.
 
@@ -138,19 +138,6 @@
 | **Status** | Open |
 | **Location** | `views_stepshifter/manager/stepshifter_manager.py:163,207` (unpickle + predict); `views_stepshifter/models/stepshifter.py:_predict_by_step` (no inverse); ADR-003 Obligations |
 | **Notes** | Commit `5fcfe43` (2025-11-20 → reverted 2026-04-11 by `08ee2eb`) forced stepshifter training into log space via `np.log1p`/`np.expm1`. An artifact pickled during that window carries log-space behavior; loaded under current raw-output code it receives **no** `expm1`, so predictions stay log-compressed but are written as raw `lr_ged_sb` — silently wrong, with **no error signal**. The 2026-06-04 `big_chungus` ensemble (MSLE 2.519, **worse than the all-zeros baseline 2.147**, ~3× the fatalities002 gold standard 0.835) is the suspected materialization; the stepshifter-family constituents are broken while the four r2darts2 DL constituents (own asinh transform) are fine. **Escalates to Tier 1** if the views-models artifact audit confirms any in-production constituent was trained in a non-raw space. ADR-003 mandates load-time guard E2 (fail-loud on a missing transform stamp), but the guard is unimplemented and the artifact audit is open. See also D-16 (separate silent prediction-output transform in the same manager path) and D-13 (numerical behavior untested). Root cause documented in `docs/ADRs/003_raw_target_space_io_contract.md`. **Falsification caveat (2026-06-08, `/falsify` P3+P6):** the audit reframes the **leading** cause as **"no target compression after the revert" (trained-raw)**, not the stale-log-artifact *mismatch* this title emphasizes — every locally inspected stepshifter artifact post-dates the revert and none from the log window were found. But the diagnosis is still **inferential**: the actual `big_chungus` constituent predictions were never inspected (the calibration reports' "Prediction Samples" were available and unused), and the actual constituent artifacts (WandB `2689xjtl`) were never opened. Confidence = "leading hypothesis", not confirmed; re-run `/falsify` after the dossier's real-data EXP-01. **EXP-01 update (2026-06-08, real mechanism):** the **trained-raw** root cause is now **confirmed** — `identity` through the centralized `target_transform` reproduces production MSLE (4.269 ≈ 4.27) *and* the mean-16-on-true-zeros signature (16.04) on real brown_cheese data (n=89,388). The *stale-log-artifact mismatch* sub-hypothesis remains secondary/unconfirmed; the constituent-artifact audit (WandB `2689xjtl`) is still open. Evidence: dossier `07_experiment_log.md` EXP-01. **Production-validated (#57–#61, 2026-06-08):** identity through `main.py -r calibration -t -e -sa` gives production MSLE 4.2687 (≈4.27) and mean prediction ~60.7 — confirming trained-raw on the real pipeline, not just the custom harness. |
-
----
-
-### D-18 — Raw-I/O contract is unfalsifiable in CI until guards E1/E2 and the gate key are implemented
-
-| Field | Value |
-|---|---|
-| **Tier** | 2 |
-| **Trigger** | When a contributor reintroduces or adds an internal target transform to `StepshifterModel` before the ADR-003 characterization test (E1), load-time guard (E2), and the gate `target_transform` key are implemented. |
-| **Source** | expert-review (2026-06-08) |
-| **Status** | Partially resolved (2026-06-13) — gate key + E1-equivalent test shipped; **E2 load-time guard still Open** |
-| **Location** | ADR-003 §"Enforcement required at ratification"; ~~`reproducibility_gate.py:24` (`CORE_GENOME` lacks `target_transform`)~~ → now `:25` (key present, validated steps 5–7); E1-equivalent test now in `tests/test_target_transforms.py`; **E2 still absent** (no load-time guard) |
-| **Notes** | ADR-003 ratifies a raw-in/raw-out contract but is documentation-only until guards E1 (fit→predict characterization test asserting raw-space output) and E2 (load-time transform-name guard) ship and `target_transform` is added to the gate. Until then, a future silent-transform commit — a `5fcfe43` rhyme — passes CI green, which is exactly the regression that produced D-17. The fix is cheap (E1 needs no registry) and should not wait for the full declarative `TRANSFORMS` mechanism. See also D-09 (gate omits keys models dereference), D-10 (gate runs only on the train path), and D-13 (existing tests verify wiring, not numerical behavior). **Update (2026-06-13, repo-assimilation):** this entry's premise is now **substantially stale**. `target_transform` IS in `CORE_GENOME` (`reproducibility_gate.py:25`) and is validated against the closed registry (steps 5–7), and an **E1-equivalent characterization test** ships and is green (`tests/test_target_transforms.py::test_predict_routes_through_inverse_exactly_once_end_to_end`, plus the `_process_data`-applies-forward-once and identity-noop tests). A silent-transform commit no longer passes CI unflagged. **What remains Open:** the ADR-003 **E2 load-time guard** (fail-loud on a missing `_target_transform_name` stamp when unpickling a pre-contract artifact) is still unimplemented — this is the residual gap and the one still tied to D-17. The doc drift this staleness reflects (ADR-001/CIC under-describe the shipped contract) is tracked separately in **D-31**. |
 
 ---
 
@@ -464,3 +451,15 @@
 | **Source** | Tech debt audit (2026-04-07); confirmed resolved by repo-assimilation (2026-06-08) |
 | **Status** | Resolved (2026-06-08) |
 | **Resolution** | The dependency is now declared: `pyproject.toml:18` reads `darts = "^0.40.0"` (uncommented), satisfying the five runtime import sites (`stepshifter.py:5`, `stepshifter.py:54,57` lazy, `hurdle_model.py:45` lazy, `darts_model.py:2`). The original entry flagged this as "likely already resolved" pending verification; verified on the 2026-06-08 assimilation audit. |
+
+---
+
+### D-18 — Raw-I/O contract is unfalsifiable in CI until guards E1/E2 and the gate key are implemented — RESOLVED
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Original trigger** | When a contributor reintroduces or adds an internal target transform to `StepshifterModel` before the ADR-003 characterization test (E1), load-time guard (E2), and the gate `target_transform` key are implemented. |
+| **Source** | expert-review (2026-06-08) |
+| **Status** | Resolved (2026-06-21) — all three ADR-003 enforcement obligations now ship |
+| **Resolution** | ADR-003 mandated three enforcement artifacts, all now present: (1) the gate `target_transform` key is in `CORE_GENOME` (`reproducibility_gate.py:25`), validated against the closed registry (steps 5–7); (2) the **E1** characterization test ships and is green (`tests/test_target_transforms.py::test_predict_routes_through_inverse_exactly_once_end_to_end`, plus `_process_data`-applies-forward-once and identity-noop tests); (3) the **E2** load-time guard now ships (Story A1, #86) — `StepshifterManager._guard_loaded_artifact` raises `PreContractArtifactError` after each `pickle.load` (`stepshifter_manager.py:29-49`, called at the evaluate/forecast load sites) when a loaded artifact lacks the `_target_transform_name` stamp, closing the frozen-pre-contract-artifact ambiguity that tied this to D-17. The guard is presence-only (a legit `log1p` artifact loads fine), per ADR-003 E2. The ADR-001/CIC doc-drift this entry once noted is tracked separately in **D-31** (Workstream C). |

--- a/tests/test_stepshifter_manager.py
+++ b/tests/test_stepshifter_manager.py
@@ -4,6 +4,7 @@ import numpy as np
 from pathlib import Path
 from unittest.mock import MagicMock, patch, mock_open
 from views_stepshifter.manager.stepshifter_manager import StepshifterManager
+from views_stepshifter.infrastructure.exceptions import PreContractArtifactError
 from views_pipeline_core.managers.model import ModelPathManager
 from views_pipeline_core.cli.args import ForecastingModelArgs
 
@@ -353,6 +354,57 @@ def test_forecast_model_artifact(stepshifter_manager):
         path_artifact = stepshifter_manager._model_path.artifacts / artifact_name
         assert path_artifact == Path("/path/to/artifacts/non_default_artifact.pkl")
         mock_logger.exception.assert_called_once_with(f"Model artifact not found at {path_artifact}")
+
+def test_load_guard_rejects_pre_contract_artifact_on_evaluate(stepshifter_manager):
+    """ADR-003 E2: an artifact missing `_target_transform_name` (a pre-contract
+    artifact) has an unknown prediction scale and MUST fail loud on load — never be
+    silently assumed to be raw space."""
+    # spec without `_target_transform_name` => hasattr(...) is False, unlike a bare MagicMock
+    pre_contract_model = MagicMock(spec=["predict"])
+    with patch("builtins.open", mock_open(read_data=b"mocked_data")), \
+        patch("pickle.load", MagicMock(return_value=pre_contract_model)):
+
+        args = ForecastingModelArgs(run_type="test_run_type", evaluate=True, saved=True)
+        stepshifter_manager.configs = vars(args)
+
+        with pytest.raises(PreContractArtifactError):
+            stepshifter_manager._evaluate_model_artifact("test_eval_type", None)
+        # the guard fires before prediction is attempted
+        pre_contract_model.predict.assert_not_called()
+
+
+def test_load_guard_rejects_pre_contract_artifact_on_forecast(stepshifter_manager):
+    """Same E2 guard on the forecast path (`_forecast_model_artifact`)."""
+    pre_contract_model = MagicMock(spec=["predict"])
+    with patch("builtins.open", mock_open(read_data=b"mocked_data")), \
+        patch("pickle.load", MagicMock(return_value=pre_contract_model)):
+
+        args = ForecastingModelArgs(run_type="forecasting", forecast=True, saved=True)
+        stepshifter_manager.configs = vars(args)
+
+        with pytest.raises(PreContractArtifactError):
+            stepshifter_manager._forecast_model_artifact(None)
+        pre_contract_model.predict.assert_not_called()
+
+
+def test_load_guard_accepts_stamped_artifact(stepshifter_manager):
+    """The guard checks for the *presence* of the stamp, not its value: a legitimate
+    artifact carrying a non-identity stamp (e.g. `log1p`) loads and predicts normally."""
+    stamped_model = MagicMock(spec=["predict", "_target_transform_name"])
+    stamped_model._target_transform_name = "log1p"
+    stamped_model.predict.return_value = ["mock_df"]
+    with patch("builtins.open", mock_open(read_data=b"mocked_data")), \
+        patch("pickle.load", MagicMock(return_value=stamped_model)), \
+        patch.object(StepshifterManager, "_get_standardized_df", return_value="standardized_df"):
+
+        args = ForecastingModelArgs(run_type="forecasting", forecast=True, saved=True)
+        stepshifter_manager.configs = vars(args)
+
+        result = stepshifter_manager._forecast_model_artifact(None)
+
+        stamped_model.predict.assert_called_once_with("forecasting")
+        assert result == "standardized_df"
+
 
 def test_evaluate_sweep(stepshifter_manager):
     """

--- a/views_stepshifter/infrastructure/exceptions.py
+++ b/views_stepshifter/infrastructure/exceptions.py
@@ -8,3 +8,15 @@ class MissingHyperparameterError(ReproducibilityError):
     """Raised when a mandatory hyperparameter is missing from the config."""
 
     pass
+
+
+class PreContractArtifactError(ReproducibilityError):
+    """Raised when a loaded model artifact predates the target-transform contract.
+
+    Per ADR-003 E2 (raw-target-space I/O contract): an artifact missing the
+    ``_target_transform_name`` stamp has an unknown prediction scale that cannot
+    be safely inverted, so it must be rejected loudly at load time rather than
+    silently assumed to be raw space.
+    """
+
+    pass

--- a/views_stepshifter/manager/stepshifter_manager.py
+++ b/views_stepshifter/manager/stepshifter_manager.py
@@ -4,6 +4,7 @@ from views_stepshifter.models.stepshifter import StepshifterModel
 from views_stepshifter.models.hurdle_model import HurdleModel
 from views_stepshifter.models.shurf_model import ShurfModel
 from views_stepshifter.infrastructure.reproducibility_gate import ReproducibilityGate
+from views_stepshifter.infrastructure.exceptions import PreContractArtifactError
 import logging
 import pickle
 import pandas as pd
@@ -23,6 +24,30 @@ class StepshifterManager(ForecastingModelManager):
         super().__init__(model_path, wandb_notifications, use_prediction_store)
         self._is_hurdle = self._config_meta["algorithm"] == "HurdleModel"
         self._is_shurf = self._config_meta["algorithm"] == "ShurfModel"
+
+    @staticmethod
+    def _guard_loaded_artifact(model: Any, path_artifact) -> None:
+        """ADR-003 E2 load-time guard.
+
+        A loaded artifact must declare the target-transform space it predicts in.
+        A pre-contract artifact (missing ``_target_transform_name``) has an unknown
+        prediction scale that cannot be safely inverted, so it is rejected loudly
+        rather than silently assumed to be raw space.
+
+        Note: the guard checks for the *presence* of the stamp, not its value — a
+        legitimate plain-model artifact may carry a non-identity transform (e.g.
+        ``log1p``) and must load fine.
+        """
+        if not hasattr(model, "_target_transform_name"):
+            msg = (
+                f"Model artifact at {path_artifact} predates the target-transform "
+                f"contract (ADR-003 E2): it carries no `_target_transform_name` stamp, "
+                f"so its prediction space is unknown and cannot be safely inverted. "
+                f"Re-train and re-save the artifact under the current contract before "
+                f"evaluating or forecasting."
+            )
+            logger.error(msg)
+            raise PreContractArtifactError(msg)
 
     @staticmethod
     def _get_standardized_df(df: pd.DataFrame) -> pd.DataFrame:
@@ -166,6 +191,8 @@ class StepshifterManager(ForecastingModelManager):
             logger.exception(f"Model artifact not found at {path_artifact}")
             raise
 
+        StepshifterManager._guard_loaded_artifact(stepshift_model, path_artifact)
+
         df_predictions = stepshift_model.predict(run_type, eval_type)
         df_predictions = [
             StepshifterManager._get_standardized_df(df) for df in df_predictions
@@ -208,6 +235,8 @@ class StepshifterManager(ForecastingModelManager):
         except FileNotFoundError:
             logger.exception(f"Model artifact not found at {path_artifact}")
             raise
+
+        StepshifterManager._guard_loaded_artifact(stepshift_model, path_artifact)
 
         df_prediction = stepshift_model.predict(run_type)
         df_prediction = StepshifterManager._get_standardized_df(df_prediction)


### PR DESCRIPTION
## A1 — ADR-003 E2 load-time stamp guard

Closes **#86** · part of EPIC **#85** (Workstream A) · resolves risk **D-18**.

### Problem
Unpickling a model artifact that predates the target-transform contract — one with **no `_target_transform_name` stamp** — proceeded silently. Its prediction space is unknown and cannot be safely inverted, the exact frozen-artifact ambiguity **ADR-003 E2** exists to close. There was no load-time guard.

### Change
- New `StepshifterManager._guard_loaded_artifact(model, path_artifact)` (`stepshifter_manager.py:29-49`): raises `PreContractArtifactError` when a loaded artifact lacks `_target_transform_name`.
- Called after each `pickle.load` — `_evaluate_model_artifact` and `_forecast_model_artifact` — placed **after** the `FileNotFoundError` handler so the guard-raise is not swallowed.
- New `PreContractArtifactError(ReproducibilityError)` in `infrastructure/exceptions.py`.

**Presence-only, not value-policing:** the guard fires on the stamp being *absent*, per ADR-003 E2's wording. A legitimate artifact carrying a non-identity transform (e.g. `log1p`) loads fine — no false positive.

### Tests (authored fresh — the old falsify P4 stub was never committed)
- `test_load_guard_rejects_pre_contract_artifact_on_evaluate` — stamp-less artifact → `PreContractArtifactError`; predict never reached.
- `test_load_guard_rejects_pre_contract_artifact_on_forecast` — same on the forecast path.
- `test_load_guard_accepts_stamped_artifact` — a `log1p`-stamped artifact loads and predicts normally.

### Verification
- `pytest tests/` → **94 passed, 7 xfailed** (3 new). `ruff check .` clean.
- `review-diff` → **CLEAN** (0 critical / 0 warning; 2 suggestions, both declined as module-consistent).

### Salvage fit
Pure salvage: fail-loud on a silently-corrupting condition; **no model-behaviour change on good artifacts**.

### Register
D-18 resolved (its last residual was E2; the gate key + E1 test already shipped) and moved to Resolved. Counts updated (Open 31 / Resolved 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
