### PR TITLE
release: bump to 1.4.0 (grid-id stripe fix — publish for ensemble retrains)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "views_stepshifter"
-version = "1.3.0"
+version = "1.4.0"
 description = ""
 authors = [
     "Xiaolong Sun <xiaolong.sun@pcr.uu.se>",


### PR DESCRIPTION
One-line version bump `1.3.0 → 1.4.0` so the grid-id "stripe" fix can be **published to PyPI**.

**Why a release is required:** ensemble constituents install `views-stepshifter>=1.0.0,<2.0.0` from **PyPI** in their own conda env; the fix is on `main` but PyPI's latest is **1.3.0 (no fix)**. Without a 1.4.0 release, an ensemble retrain silently re-bakes the stripe (D-28). Publishing 1.4.0 lets the pin pull the fix.

**Contents of 1.4.0** (already merged + tested on main): D-41 grid-id `use_static_covariates=False` fix for plain `StepshifterModel` (#96) and its `HurdleModel`/`ShurfModel` extension (#99).

No code change here — version line only. `pipeline_core` stays `>=2.0.0,<3.0.0`. Suite green (95 passed / 7 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)